### PR TITLE
chore(release): v1.2.0 

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -46,8 +46,8 @@ jobs:
         # FUTURE: update when dart 3 is released.
         # SYNC: update when env.sdk support range is changed.
         # TODO: test on multiple sdks.
-        # container: ["google/dart:2.5.2", "google/dart:2", "google/dart:latest"]
-        container: ["google/dart:2"]
+        # Testing with "google/dart:latest" is preemptive prepare for dart v3 in future.
+        container: ["google/dart:2.1.1", "google/dart:2", "google/dart:latest"]
     env:
       PUB_CACHE: ~/.pub-cache
     container:
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
-          # Make it sure to sync with $PUB_CACHE above.
+          # SYNC: with $PUB_CACHE above.
           path: ~/.pub-cache
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: |
@@ -70,6 +70,7 @@ jobs:
   publish:
     needs: test
     # SYNC: modify to 'refs/tags/v2.' when v2 is released.
+    # only runs if name of git tag starts with 'v1.' and on branch main
     if: startsWith(github.ref, 'refs/tags/v1.') && ( github.event.base_ref == 'refs/heads/main' )
     runs-on: ubuntu-latest
     env:
@@ -96,7 +97,6 @@ jobs:
           EOF
 
       - name: Publish To Pub.dev
-        # only runs if name of git tag starts with 'v1.' and on branch master
         # `--force` option: Publish without confirmation if there are no errors.
         run: |
           pub publish --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 <!-- markdownlint-disable-file MD041 -->
 
+## 1.2.0
+
+- Support wide range of sdk: `>=2.1.1 <3.0.0`.
+
+## 1.1.0
+
+- Expose `decodeString()`.
+- Expose `encodeToString()`.
+
+# 1.0.0
+
+Not changed from 0.1.0. Just the first stable release.
+
 ## 0.1.0
 
 - Expose `encode()`.
 
 ## 0.0.1
 
-- Expose `decode()` and toUnicodes()`.
+- Expose `decode()` and `toUnicodes()`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,11 @@ version: 1.1.0
 description: CP949 Encoder/Decoder
 environment:
   # SYNC: with CI config when sdk support range is changed.
-  sdk: ">=2.5.2 <3.0.0"
+  sdk: ">=2.1.1 <3.0.0"
 homepage: https://github.com/jjangga0214/dart-cp949
 repository: https://github.com/jjangga0214/dart-cp949
 issue_tracker: https://github.com/jjangga0214/dart-cp949/issues
 documentation: https://github.com/jjangga0214/dart-cp949
 dev_dependencies:
-  test: ^1.15.4
+  # package:test v1.5.3 support sdk v2.1.0, and CI uses sdk v2.1.1 as a lower compatibility boundary
+  test: ">=1.5.3 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cp949
-version: 1.1.0
+version: 1.2.0
 description: CP949 Encoder/Decoder
 environment:
   # SYNC: with CI config when sdk support range is changed.


### PR DESCRIPTION
- build: support a wider range of sdk. 
- ci: test with multiple sdks.